### PR TITLE
Check to make sure the payload exists before attempting to use it.

### DIFF
--- a/lib/client/fast_render.js
+++ b/lib/client/fast_render.js
@@ -25,7 +25,7 @@ FastRender.injectDdpMessage = function(conn, message) {
 };
 
 FastRender.init = function(payload) {
-  if(FastRender._disable) return;
+  if(FastRender._disable || _.isNull(payload) || _.isUndefined(payload) || _.isEmpty(payload)) return;
 
   FastRender._securityCheck(payload);
 


### PR DESCRIPTION
This fixes an undefined reference error I am seeing when visiting the initial page of my app. Note that fast-render still seems to work otherwise.